### PR TITLE
Replaced `:elixir_errors` to work with Elixir 1.9

### DIFF
--- a/lib/pipe_to.ex
+++ b/lib/pipe_to.ex
@@ -33,10 +33,10 @@ defmodule PipeTo do
       case x do
         {op, _, [_]} when op == :+ or op == :- ->
           message =
-            <<"piping into a unary operator is deprecated, please use the ",
-              "qualified name. For example, Kernel.+(5), instead of +5">>
+            "piping into a unary operator is deprecated, please use the " <>
+              "qualified name. For example, Kernel.+(5), instead of +5"
 
-          :elixir_errors.warn(__CALLER__.line, __CALLER__.file, message)
+          IO.warn(message, Macro.Env.stacktrace(__CALLER__))
 
         _ ->
           :ok

--- a/test/pipe_to/override_test.exs
+++ b/test/pipe_to/override_test.exs
@@ -15,7 +15,7 @@ defmodule PipeTo.OverrideToTest do
   test "works like normal pipe" do
     result = ~w(a b c)a
     |> Enum.zip(3..1)
-    |> Enum.sort_by(fn {k, v} -> v end)
+    |> Enum.sort_by(fn {_, v} -> v end)
 
     assert result == [c: 1, b: 2, a: 3]
   end


### PR DESCRIPTION
Fixes #4 